### PR TITLE
Switch accuracy comparison to ERA5 reanalysis

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
           <path d="M3 8c4-2 6-2 9-2s5 0 9 2" stroke="#c6a5ff" stroke-width="1.5" stroke-linecap="round"/>
         </svg>
         <h1 style="margin:0;font-size:18px">24‑часовой прогноз ветра — Владивосток · Сравнение моделей</h1>
-        <span class="badge" id="bestBadge" title="Лидер точности за последние 24ч">—</span>
+        <span class="badge" id="bestBadge" title="Лидер точности (ERA5) за последние 24ч">—</span>
       </div>
       <div class="controls">
         <button class="chip" id="refreshBtn" type="button">Обновить</button>
@@ -88,14 +88,12 @@
         <label>
           <input id="lon" type="number" step="0.000001" value="131.874660" title="Долгота (база Силы ветра)" />
         </label>
-        <label>METAR станция:
-          <input id="metarStation" type="text" value="UHWW" title="ICAO код (напр., UHWW — Vladivostok/Knevichi)" maxlength="4" style="text-transform:uppercase;width:90px" />
-        </label>
+        <span class="muted small">Факт: ERA5 (реанализ)</span>
         <button class="chip" type="submit">Применить</button>
         <button class="chip" type="button" id="scoreBtn">Оценить точность (24ч)</button>
         <span class="muted small right" id="fetchInfo">—</span>
       </form>
-      <div class="small muted" style="margin-top:6px">Адрес: ул. Батарейная, 3 (ориентир: Спортивная гавань). Координаты по справочникам: 43.120261, 131.874660. Факт берем из METAR аэропорта <b>UHWW</b> (VVO) — ~35 км от базы; для воды возможна систематическая разница.</div>
+      <div class="small muted" style="margin-top:6px">Адрес: ул. Батарейная, 3 (ориентир: Спортивная гавань). Координаты по справочникам: 43.120261, 131.874660. Факт для оценки точности берем из реанализа <b>ERA5</b> (клетка на ту же точку); для воды возможна систематическая разница.</div>
     </div>
 
     <div id="errorBox" class="err" style="display:none"></div>
@@ -117,7 +115,7 @@
 
     <div id="scoreCard" class="card" style="display:none">
       <div class="grid" style="margin-bottom:8px">
-        <div class="muted small">Сравнение точности за последние 24ч (по METAR станции). Метрика: MAE по скорости (м/с) + справочно MAE по направлению (°). Победитель подсвечен цветом.</div>
+        <div class="muted small">Сравнение точности за последние 24ч (по реанализу ERA5). Метрика: MAE по скорости (м/с) + справочно MAE по направлению (°). Победитель подсвечен цветом.</div>
         <div class="small right" id="obsInfo">—</div>
       </div>
       <div class="score" id="scoreTable">
@@ -152,9 +150,22 @@
         scoreBtn: document.getElementById('scoreBtn'),
         bestBadge: document.getElementById('bestBadge'),
         scoreCard: document.getElementById('scoreCard'), scoreTable: document.getElementById('scoreTable'), obsInfo: document.getElementById('obsInfo'),
-        metarStation: document.getElementById('metarStation'),
         testBtn: document.getElementById('testBtn')
       };
+
+      const HOUR_KEY_FMT = new Intl.DateTimeFormat('en-CA',{ timeZone: TIMEZONE, hour12:false, year:'numeric', month:'2-digit', day:'2-digit', hour:'2-digit' });
+      const RANGE_FMT = new Intl.DateTimeFormat('ru-RU',{ timeZone: TIMEZONE, hour:'2-digit', day:'2-digit', month:'short' });
+      const DATE_FMT = new Intl.DateTimeFormat('en-CA',{ timeZone: TIMEZONE, year:'numeric', month:'2-digit', day:'2-digit' });
+
+      function hourKey(epoch){ return HOUR_KEY_FMT.format(epoch); }
+      function describeRange(range){
+        if(!range) return '—';
+        const start = RANGE_FMT.format(range.start);
+        const end = RANGE_FMT.format(range.end);
+        return start===end? start : `${start} → ${end}`;
+      }
+      function alignToHour(date){ const d = new Date(date); d.setMinutes(0,0,0); return d; }
+      function formatLocalDate(date){ return DATE_FMT.format(date); }
 
       function fmtOffset(sec){ const sign = sec>=0?'+':'-'; const a=Math.abs(sec); const h=Math.floor(a/3600); const m=Math.floor((a%3600)/60); return sign+String(h).padStart(2,'0')+':'+String(m).padStart(2,'0'); }
       function toEpochLocalIso(isoLocal, off){ return Date.parse(isoLocal + fmtOffset(off)); }
@@ -247,74 +258,44 @@
         el.tbody.innerHTML = rowsHtml || '<tr><td colspan="10" class="muted">Нет данных</td></tr>';
       }
 
-      // === Accuracy against METAR ===
-      function nearestHourLocal(date){
-        const d = new Date(date); const m = d.getMinutes(); d.setMinutes(0,0,0);
-        if(m>=30) d.setHours(d.getHours()+1); return d;
-      }
+      // === Accuracy против факта (ERA5) ===
       function degDiff(a,b){ if(a==null||b==null) return null; let d = Math.abs(((a - b + 540) % 360) - 180); return d; }
 
-      async function fetchMETAR(station){
-        const base = `https://aviationweather.gov/adds/dataserver_current/httpparam?datasource=metars&requestType=retrieve&format=geojson&stationString=${encodeURIComponent(station)}&hoursBeforeNow=24`;
-
-        async function fetchJSON(url){
-          const r = await fetch(url, { cache:'no-cache' });
-          if(!r.ok) throw new Error(`HTTP ${r.status}`);
-          return await r.json();
-        }
-        async function fetchJSONWithFallback(url){
-          // 1) Try direct (likely CORS-blocked)
-          try{ return await fetchJSON(url); }
-          catch(e1){
-            // 2) Try Netlify Function proxy if deployed there
-            try{
-              const prox = '/.netlify/functions/proxy?url=' + encodeURIComponent(url);
-              const r2 = await fetch(prox, { cache:'no-cache' });
-              if(!r2.ok) throw new Error(`Netlify proxy HTTP ${r2.status}`);
-              const txt2 = await r2.text();
-              try { return JSON.parse(txt2); } catch(e){ throw new Error('Netlify proxy non-JSON'); }
-            }catch(e2){
-              // 3) Fallback to AllOrigins
-              try{
-                const ao = 'https://api.allorigins.win/raw?url=' + encodeURIComponent(url);
-                const r3 = await fetch(ao, { cache:'no-cache' });
-                if(!r3.ok) throw new Error(`AllOrigins HTTP ${r3.status}`);
-                const txt3 = await r3.text();
-                try { return JSON.parse(txt3); } catch(e){ throw new Error('AllOrigins non-JSON'); }
-              }catch(e3){
-                throw new Error(`${e1.message} | ${e2.message} | ${e3.message}`);
-              }
-            }
-          }
-        }
-
-        const j = await fetchJSONWithFallback(base);
-        const feats = j && j.features ? j.features : [];
-        const records = feats.map(f=>f.properties).filter(p=>p);
-        const tz = TIMEZONE;
+      async function fetchEra5Fact(lat, lon){
+        const nowAligned = alignToHour(Date.now());
+        const start = new Date(nowAligned.getTime() - HRS_AHEAD*3600*1000);
+        const params = new URLSearchParams({
+          latitude: String(lat),
+          longitude: String(lon),
+          start_date: formatLocalDate(start),
+          end_date: formatLocalDate(nowAligned),
+          hourly: 'wind_speed_10m,wind_direction_10m,wind_gusts_10m',
+          timezone: TIMEZONE,
+          wind_speed_unit: 'ms'
+        });
+        const url = 'https://api.open-meteo.com/v1/era5?' + params.toString();
+        const r = await fetch(url, { cache:'no-cache' });
+        if(!r.ok) throw new Error(`ERA5 HTTP ${r.status}`);
+        const j = await r.json();
+        const rows = takePast24(j);
         const map = new Map();
-        for(const p of records){
-          const iso = p.observation_time; // UTC time string
-          const utcMs = Date.parse(iso);
-          const fmt = new Intl.DateTimeFormat('en-CA', { timeZone: tz, hour12:false, year:'numeric', month:'2-digit', day:'2-digit', hour:'2-digit'});
-          const key = fmt.format(nearestHourLocal(new Date(utcMs)).getTime());
-          const spKt = Number(p.wind_speed_kt); const gsKt = p.wind_gust_kt!=null? Number(p.wind_gust_kt): null; const dir = p.wind_dir_degrees!=null? Number(p.wind_dir_degrees): null;
-          const sp = isFinite(spKt)? spKt*0.514444 : null; const gs = isFinite(gsKt)? gsKt*0.514444 : null;
-          map.set(key, { sp, gs, dir, raw:p.raw_text, time: p.observation_time });
+        let min = null, max = null;
+        for(const rec of rows){
+          map.set(hourKey(rec.epoch), rec);
+          if(min===null || rec.epoch < min) min = rec.epoch;
+          if(max===null || rec.epoch > max) max = rec.epoch;
         }
-        return { station, map, count: records.length };
+        const range = min!=null? { start:min, end:max } : null;
+        return { source:'ERA5', map, count: rows.length, range };
       }
 
       function buildPastKeyIndex(){
         const idx = {};
-        const fmt = new Intl.DateTimeFormat('en-CA',{ timeZone: TIMEZONE, hour12:false, year:'numeric', month:'2-digit', day:'2-digit', hour:'2-digit'});
         for(const s of SOURCES){
           const map = state.pastMaps[s.id] || new Map();
           const m2 = new Map();
-          for(const [t, rec] of map.entries()){
-            const epoch = rec.epoch;
-            const key = fmt.format(epoch);
-            m2.set(key, rec);
+          for(const rec of map.values()){
+            m2.set(hourKey(rec.epoch), rec);
           }
           idx[s.id] = m2;
         }
@@ -323,10 +304,12 @@
 
       async function assessAccuracy(){
         try{
-          const station = (el.metarStation.value||'UHWW').trim().toUpperCase();
-          el.error.style.display='none'; el.obsInfo.textContent='Загрузка METAR…';
-          const obs = await fetchMETAR(station);
-          el.obsInfo.textContent = `METAR ${station}: записей ${obs.count}`;
+          const lat = parseFloat(el.lat.value); const lon = parseFloat(el.lon.value);
+          if(!Number.isFinite(lat) || !Number.isFinite(lon)) throw new Error('уточните координаты');
+          el.error.style.display='none'; el.obsInfo.textContent='ERA5: загрузка…';
+          const obs = await fetchEra5Fact(lat, lon);
+          const coverageTxt = obs.count? `ERA5 · ${obs.count} точек · ${describeRange(obs.range)}` : 'ERA5: нет данных за последние 24ч';
+          el.obsInfo.textContent = coverageTxt;
           state.obs = obs;
           const idx = buildPastKeyIndex();
 
@@ -334,21 +317,21 @@
           let best = null;
           for(const s of SOURCES){
             const m = idx[s.id] || new Map();
-            let n=0, sumSp=0, sumDir=0;
+            let n=0, sumSp=0, sumDir=0, cntSp=0, cntDir=0;
             for(const [key, o] of obs.map.entries()){
               const rec = m.get(key);
               if(!rec) continue;
               const eSp = (o.sp!=null && rec.sp!=null)? Math.abs(rec.sp - o.sp) : null;
               const eDir = (o.dir!=null && rec.dir!=null)? degDiff(rec.dir, o.dir) : null;
               if(eSp==null && eDir==null) continue;
-              if(eSp!=null){ sumSp += eSp; }
-              if(eDir!=null){ sumDir += eDir; }
+              if(eSp!=null){ sumSp += eSp; cntSp++; }
+              if(eDir!=null){ sumDir += eDir; cntDir++; }
               n++;
             }
-            const maeSp = n? (sumSp/n) : null;
-            const maeDir = n? (sumDir/n) : null;
+            const maeSp = cntSp? (sumSp/cntSp) : null;
+            const maeDir = cntDir? (sumDir/cntDir) : null;
             results.push({ id:s.id, name:s.name, n, maeSp, maeDir });
-            if(n && maeSp!=null){
+            if(cntSp && maeSp!=null){
               if(!best || maeSp < best.maeSp - 1e-6 || (Math.abs(maeSp - best.maeSp) < 1e-6 && (maeDir??1e9) < (best.maeDir??1e9))){
                 best = { id:s.id, name:s.name, maeSp, maeDir, n };
               }
@@ -367,12 +350,13 @@
           el.scoreCard.style.display = 'block';
 
           state.best = best? best.id : null;
-          el.bestBadge.textContent = best? `Лучший за 24ч: ${best.name} (MAE ${(Math.round(best.maeSp*10)/10).toFixed(1)} м/с)` : '—';
+          el.bestBadge.textContent = best? `Лучший (ERA5): ${best.name} · ${(Math.round(best.maeSp*10)/10).toFixed(1)} м/с` : '—';
           render();
         }catch(e){
-          el.error.textContent = `Оценка точности не удалась: ${e.message}
-Возможная причина — CORS/прокси. Если сайт на Netlify, убедитесь, что функция /.netlify/functions/proxy задеплоена.
-Код станции проверьте (например, UHWW).`;
+          state.best = null;
+          el.scoreCard.style.display = 'none';
+          render();
+          el.error.textContent = `Оценка точности не удалась: ${e.message}. Попробуйте позже.`;
           el.error.style.display = 'block';
         }
       }


### PR DESCRIPTION
## Summary
- switch the 24h accuracy assessment from METAR via proxy to ERA5 reanalysis and compute MAE per metric
- surface the ERA5 data source in the UI and keep the best forecast column highlighted based on the new scores
- tidy the scoreboard messaging and badge text for the updated workflow

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c9643249b4832291f7557dff16ff78